### PR TITLE
afpd: Return the correct error for non-existent volume

### DIFF
--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -2313,7 +2313,7 @@ int afp_openvol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
     }
 
     if ( volume == NULL ) {
-        return AFPERR_PARAM;
+        return AFPERR_NOOBJ;
     }
 
     /* check for a volume password */


### PR DESCRIPTION
Backport from 3.x to fix bug# 577

https://sourceforge.net/p/netatalk/bugs/577/